### PR TITLE
Fix: Start Planning button functionality

### DIFF
--- a/app/components/welcome_section.rb
+++ b/app/components/welcome_section.rb
@@ -62,7 +62,8 @@ class WelcomeSection < ApplicationComponent
               p class: "text-gray-600" do
                 "Ready to plan your next adventure?"
               end
-              button class: "group relative inline-flex items-center justify-center px-8 py-4 text-lg font-medium text-white transition-all duration-300 bg-gradient-to-r from-primary-600 to-accent-600 rounded-full hover:from-primary-700 hover:to-accent-700 hover:shadow-2xl hover:scale-105 focus:outline-none focus:ring-4 focus:ring-primary-300" do
+              link_to new_road_trip_path,
+                     class: "group relative inline-flex items-center justify-center px-8 py-4 text-lg font-medium text-white transition-all duration-300 bg-gradient-to-r from-primary-600 to-accent-600 rounded-full hover:from-primary-700 hover:to-accent-700 hover:shadow-2xl hover:scale-105 focus:outline-none focus:ring-4 focus:ring-primary-300" do
                 span class: "relative z-10" do
                   "Start Planning"
                 end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe "Pages", type: :request do
+  describe "GET /" do
+    context "when user is not logged in" do
+      it "returns successful response" do
+        get root_path
+        expect(response).to have_http_status(:success)
+      end
+
+      it "displays Get Started and Sign In buttons" do
+        get root_path
+        expect(response.body).to include("Get Started")
+        expect(response.body).to include("Sign In")
+      end
+
+      it "does not display Start Planning button" do
+        get root_path
+        expect(response.body).not_to include("Start Planning")
+      end
+    end
+
+    context "when user is logged in" do
+      let(:user) { create(:user) }
+
+      before do
+        post login_path, params: { username: user.username, password: user.password }
+      end
+
+      it "returns successful response" do
+        get root_path
+        expect(response).to have_http_status(:success)
+      end
+
+      it "displays welcome message with username" do
+        get root_path
+        expect(response.body).to include("Welcome back, #{user.username}!")
+      end
+
+      it "displays Start Planning button" do
+        get root_path
+        expect(response.body).to include("Start Planning")
+      end
+
+      it "Start Planning button links to new road trip page" do
+        get root_path
+        expect(response.body).to include(new_road_trip_path)
+      end
+
+      it "does not display Get Started or Sign In buttons" do
+        get root_path
+        expect(response.body).not_to include("Get Started")
+        expect(response.body).not_to include("Sign In")
+      end
+    end
+  end
+
+  describe "Start Planning button functionality" do
+    let(:user) { create(:user) }
+
+    before do
+      post login_path, params: { username: user.username, password: user.password }
+    end
+
+    it "clicking Start Planning redirects to new road trip page" do
+      get root_path
+      expect(response.body).to include('href="/road_trips/new"')
+      
+      # Verify the new road trip page is accessible
+      get new_road_trip_path
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("Create New Road Trip")
+    end
+
+    it "new road trip page requires authentication" do
+      delete logout_path # Log out first
+      
+      get new_road_trip_path
+      expect(response).to redirect_to(login_path)
+    end
+  end
+end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Pages", type: :request do
     it "clicking Start Planning redirects to new road trip page" do
       get root_path
       expect(response.body).to include('href="/road_trips/new"')
-      
+
       # Verify the new road trip page is accessible
       get new_road_trip_path
       expect(response).to have_http_status(:success)
@@ -74,7 +74,7 @@ RSpec.describe "Pages", type: :request do
 
     it "new road trip page requires authentication" do
       delete logout_path # Log out first
-      
+
       get new_road_trip_path
       expect(response).to redirect_to(login_path)
     end


### PR DESCRIPTION
## Summary
• Fixed the non-functional "Start Planning" button on the homepage for logged-in users
• Button now properly links to the new road trip creation page using Rails `link_to` helper
• Added comprehensive RSpec tests to prevent regression

## Changes Made
- **Fixed Button**: Converted plain HTML button to proper `link_to` helper in `WelcomeSection` component
- **Added Tests**: Created complete test suite in `spec/requests/pages_spec.rb` covering:
  - Homepage rendering for logged-in and logged-out users
  - Button presence and linking functionality  
  - Authentication requirements for new trip page
  - Different user scenarios and edge cases

## Test Plan
- [x] Button appears only for logged-in users
- [x] Button links to `/road_trips/new` correctly  
- [x] New road trip page loads properly
- [x] Unauthenticated users are redirected to login
- [x] Comprehensive RSpec tests cover all scenarios
- [x] Visual styling preserved (same CSS classes)

Fixes #31

🤖 Generated with [Claude Code](https://claude.ai/code)