### PR TITLE
Feature: Option to avoid motorways

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,7 @@ end
 - Road trip sharing with other users (add participants, leave functionality, access control)
 - Fuel economy calculator with real-time cost calculations (client-side JavaScript)
 - Route waypoints for route manipulation (interactive map-based waypoint setting, ordering, removal)
+- Motorway avoidance option for routes (checkbox in route creation forms affects route calculation)
 
 ### 🚧 In Progress
 - None currently

--- a/app/components/routes/form_page_component.rb
+++ b/app/components/routes/form_page_component.rb
@@ -93,6 +93,23 @@ class Routes::FormPageComponent < ApplicationComponent
               end
             end
 
+            # Avoid Motorways Option
+            div class: "flex items-center" do
+              form.check_box :avoid_motorways,
+                             class: "h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+
+              form.label :avoid_motorways,
+                         class: "ml-2 block text-sm text-gray-900" do
+                "Avoid motorways and highways"
+              end
+
+              if @route.errors[:avoid_motorways].any?
+                div class: "ml-6 mt-1 text-sm text-red-600" do
+                  @route.errors[:avoid_motorways].first
+                end
+              end
+            end
+
             # Date & Time (only for edit mode)
             if @is_edit_mode
               render Shared::DateInputComponent.new(
@@ -156,6 +173,23 @@ class Routes::FormPageComponent < ApplicationComponent
                 if @route.errors[:destination].any?
                   div class: "mt-1 text-sm text-red-600" do
                     @route.errors[:destination].first
+                  end
+                end
+              end
+
+              # Avoid Motorways Option
+              div class: "flex items-center" do
+                form.check_box :avoid_motorways,
+                               class: "h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+
+                form.label :avoid_motorways,
+                           class: "ml-2 block text-sm text-gray-900" do
+                  "Avoid motorways and highways"
+                end
+
+                if @route.errors[:avoid_motorways].any?
+                  div class: "ml-6 mt-1 text-sm text-red-600" do
+                    @route.errors[:avoid_motorways].first
                   end
                 end
               end

--- a/app/controllers/routes_controller.rb
+++ b/app/controllers/routes_controller.rb
@@ -18,7 +18,8 @@ class RoutesController < ApplicationController
     session[:route_data] = {
       "road_trip_id" => @road_trip.id,
       "starting_location" => @route.starting_location,
-      "destination" => @route.destination
+      "destination" => @route.destination,
+      "avoid_motorways" => @route.avoid_motorways
     }
 
     if @route.valid?(:location_only)
@@ -71,6 +72,7 @@ class RoutesController < ApplicationController
       starting_location: route_data["starting_location"],
       destination: route_data["destination"],
       datetime: params[:datetime],
+      avoid_motorways: route_data["avoid_motorways"] || false,
       user: current_user
     )
 
@@ -182,10 +184,10 @@ class RoutesController < ApplicationController
   end
 
   def route_create_params
-    params.require(:route).permit(:starting_location, :destination)
+    params.require(:route).permit(:starting_location, :destination, :avoid_motorways)
   end
 
   def route_params
-    params.require(:route).permit(:starting_location, :destination, :datetime)
+    params.require(:route).permit(:starting_location, :destination, :datetime, :avoid_motorways)
   end
 end

--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -9,7 +9,7 @@ class Route < ApplicationRecord
   validate :datetime_not_overlapping_with_other_routes, unless: -> { validation_context == :location_only }
   validate :user_matches_road_trip_user
 
-  before_save :calculate_route_metrics, if: :locations_changed?
+  before_save :calculate_route_metrics, if: :locations_changed_or_motorway_setting_changed?
 
   scope :for_user, ->(user) { where(user: user) }
   scope :ordered_by_datetime, -> { order(:datetime) }
@@ -59,12 +59,16 @@ class Route < ApplicationRecord
     starting_location_changed? || destination_changed?
   end
 
+  def locations_changed_or_motorway_setting_changed?
+    locations_changed? || avoid_motorways_changed?
+  end
+
   def calculate_route_metrics
     return unless starting_location.present? && destination.present?
 
     # Include waypoints in calculation if they exist - convert to array for compatibility
     ordered_waypoints = waypoints.ordered.to_a
-    calculator = RouteDistanceCalculator.new(starting_location, destination, ordered_waypoints)
+    calculator = RouteDistanceCalculator.new(starting_location, destination, ordered_waypoints, avoid_motorways: avoid_motorways?)
     result = calculator.calculate
 
     self.distance = result[:distance]
@@ -75,8 +79,8 @@ class Route < ApplicationRecord
   def calculate_and_save_route_metrics
     return { distance: nil, duration: nil } unless starting_location.present? && destination.present?
 
-    # Only calculate if we don't have both values
-    if distance.nil? || duration.nil?
+    # Only calculate if we don't have both values or if motorway setting may have changed metrics
+    if distance.nil? || duration.nil? || avoid_motorways_changed?
       calculate_route_metrics
       save if persisted? && (distance_changed? || duration_changed?)
     end

--- a/app/services/route_distance_calculator.rb
+++ b/app/services/route_distance_calculator.rb
@@ -5,10 +5,11 @@ require "uri"
 class RouteDistanceCalculator
   attr_reader :distance_km, :duration_hours
 
-  def initialize(starting_location, destination, waypoints = [])
+  def initialize(starting_location, destination, waypoints = [], avoid_motorways: false)
     @starting_location = starting_location
     @destination = destination
     @waypoints = waypoints || []
+    @avoid_motorways = avoid_motorways
     @distance_km = nil
     @duration_hours = nil
   end
@@ -117,6 +118,12 @@ class RouteDistanceCalculator
       overview: "false",
       geometries: "geojson"
     }
+
+    # Add avoid parameter for motorways if requested
+    if @avoid_motorways
+      params[:avoid] = "motorway"
+    end
+
     uri.query = URI.encode_www_form(params)
 
     response = Net::HTTP.get_response(uri)
@@ -148,6 +155,12 @@ class RouteDistanceCalculator
       overview: "false",
       geometries: "geojson"
     }
+
+    # Add avoid parameter for motorways if requested
+    if @avoid_motorways
+      params[:avoid] = "motorway"
+    end
+
     uri.query = URI.encode_www_form(params)
 
     response = Net::HTTP.get_response(uri)

--- a/db/migrate/20250915091544_add_avoid_motorways_to_routes.rb
+++ b/db/migrate/20250915091544_add_avoid_motorways_to_routes.rb
@@ -1,0 +1,5 @@
+class AddAvoidMotorwaysToRoutes < ActiveRecord::Migration[8.0]
+  def change
+    add_column :routes, :avoid_motorways, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_14_204131) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_15_091544) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -62,6 +62,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_14_204131) do
     t.float "distance"
     t.float "duration"
     t.datetime "waypoints_updated_at"
+    t.boolean "avoid_motorways", default: false, null: false
     t.index ["road_trip_id"], name: "index_routes_on_road_trip_id"
     t.index ["user_id"], name: "index_routes_on_user_id"
   end

--- a/spec/factories/routes.rb
+++ b/spec/factories/routes.rb
@@ -30,5 +30,9 @@ FactoryBot.define do
       end
       datetime { hours_from_now.hours.from_now }
     end
+
+    trait :avoiding_motorways do
+      avoid_motorways { true }
+    end
   end
 end

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe Route, type: :model do
       it 'calculates and saves the distance' do
         calculator = instance_double(RouteDistanceCalculator)
         allow(RouteDistanceCalculator).to receive(:new)
-          .with(route.starting_location, route.destination, [])
+          .with(route.starting_location, route.destination, [], avoid_motorways: false)
           .and_return(calculator)
         allow(calculator).to receive(:calculate).and_return({ distance: 120.5, duration: 2.5 })
 
@@ -264,7 +264,7 @@ RSpec.describe Route, type: :model do
     it 'calculates distance and duration when creating a new route' do
       calculator = instance_double(RouteDistanceCalculator)
       allow(RouteDistanceCalculator).to receive(:new)
-        .with("New York", "Boston", [])
+        .with("New York", "Boston", [], avoid_motorways: false)
         .and_return(calculator)
       allow(calculator).to receive(:calculate).and_return({ distance: 250.0, duration: 4.5 })
 
@@ -286,7 +286,7 @@ RSpec.describe Route, type: :model do
 
       calculator = instance_double(RouteDistanceCalculator)
       allow(RouteDistanceCalculator).to receive(:new)
-        .with("Chicago", route.destination, [])
+        .with("Chicago", route.destination, [], avoid_motorways: false)
         .and_return(calculator)
       allow(calculator).to receive(:calculate).and_return({ distance: 300.0, duration: 5.5 })
 
@@ -332,7 +332,7 @@ RSpec.describe Route, type: :model do
       it 'forces recalculation of route metrics' do
         calculator = instance_double(RouteDistanceCalculator)
         allow(RouteDistanceCalculator).to receive(:new)
-          .with(route.starting_location, route.destination, [])
+          .with(route.starting_location, route.destination, [], avoid_motorways: false)
           .and_return(calculator)
         allow(calculator).to receive(:calculate).and_return({ distance: 500.0, duration: 7.5 })
 
@@ -349,7 +349,7 @@ RSpec.describe Route, type: :model do
 
         calculator = instance_double(RouteDistanceCalculator)
         allow(RouteDistanceCalculator).to receive(:new)
-          .with(route.starting_location, route.destination, [ waypoint ])
+          .with(route.starting_location, route.destination, [ waypoint ], avoid_motorways: false)
           .and_return(calculator)
         allow(calculator).to receive(:calculate).and_return({ distance: 600.0, duration: 8.5 })
 
@@ -419,7 +419,7 @@ RSpec.describe Route, type: :model do
         it 'triggers recalculation and returns updated duration' do
           calculator = instance_double(RouteDistanceCalculator)
           allow(RouteDistanceCalculator).to receive(:new)
-            .with(route.starting_location, route.destination, [ waypoint ])
+            .with(route.starting_location, route.destination, [ waypoint ], avoid_motorways: false)
             .and_return(calculator)
           allow(calculator).to receive(:calculate).and_return({ distance: 400.0, duration: 5.0 })
 

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -473,7 +473,7 @@ RSpec.describe Route, type: :model do
           waypoint = create(:waypoint, route: route, latitude: 40.7128, longitude: -74.0060)
 
           expect(RouteDistanceCalculator).to receive(:new)
-            .with(route.starting_location, route.destination, [waypoint], avoid_motorways: true)
+            .with(route.starting_location, route.destination, [ waypoint ], avoid_motorways: true)
             .and_call_original
 
           route.send(:calculate_route_metrics)

--- a/spec/models/waypoint_spec.rb
+++ b/spec/models/waypoint_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe Waypoint, type: :model do
 
       # When route metrics are recalculated, they should include the waypoint
       allow(RouteDistanceCalculator).to receive(:new)
-        .with(route.starting_location, route.destination, [ waypoint ])
+        .with(route.starting_location, route.destination, [ waypoint ], avoid_motorways: false)
         .and_return(calculator)
       allow(calculator).to receive(:calculate)
         .and_return({ distance: 250.0, duration: 4.5 })

--- a/spec/requests/waypoints_spec.rb
+++ b/spec/requests/waypoints_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe WaypointsController, type: :controller do
       # Mock the route calculator to return updated metrics
       calculator = instance_double(RouteDistanceCalculator)
       allow(RouteDistanceCalculator).to receive(:new)
-        .with(route.starting_location, route.destination, [ waypoint ])
+        .with(route.starting_location, route.destination, [ waypoint ], avoid_motorways: false)
         .and_return(calculator)
       allow(calculator).to receive(:calculate).and_return({ distance: 450.0, duration: 7.0 })
 

--- a/spec/services/route_distance_calculator_spec.rb
+++ b/spec/services/route_distance_calculator_spec.rb
@@ -20,6 +20,16 @@ RSpec.describe RouteDistanceCalculator do
       calculator = described_class.new(start_location, destination)
       expect(calculator.instance_variable_get(:@waypoints)).to eq([])
     end
+
+    it 'accepts avoid_motorways parameter' do
+      calculator = described_class.new(start_location, destination, [], avoid_motorways: true)
+      expect(calculator.instance_variable_get(:@avoid_motorways)).to be true
+    end
+
+    it 'defaults avoid_motorways to false' do
+      calculator = described_class.new(start_location, destination)
+      expect(calculator.instance_variable_get(:@avoid_motorways)).to be false
+    end
   end
 
   describe '#calculate' do
@@ -192,6 +202,60 @@ RSpec.describe RouteDistanceCalculator do
       it 'handles coordinate array format waypoints' do
         result = calculator.calculate
         expect(result[:distance]).to eq(450.0)
+      end
+    end
+  end
+
+  describe 'avoid_motorways functionality' do
+    context 'when avoid_motorways is enabled' do
+      let(:calculator) { described_class.new(start_location, destination, [], avoid_motorways: true) }
+
+      before do
+        allow(calculator).to receive(:geocode).with(start_location)
+                                              .and_return([ 40.7128, -74.0060 ])
+        allow(calculator).to receive(:geocode).with(destination)
+                                              .and_return([ 42.3601, -71.0589 ])
+        allow(Net::HTTP).to receive(:get_response).and_return(
+          instance_double(Net::HTTPSuccess, is_a?: true, body: {
+            routes: [{ distance: 350000, duration: 16200 }] # Longer route avoiding motorways
+          }.to_json)
+        )
+      end
+
+      it 'passes avoid parameter to OSRM API' do
+        expect(URI).to receive(:new).with(
+          "https://router.project-osrm.org/route/v1/driving/-74.0060,40.7128;-71.0589,42.3601"
+        ).and_call_original
+
+        expect(URI).to receive(:encode_www_form).with(
+          hash_including(avoid: "motorway")
+        ).and_call_original
+
+        calculator.calculate
+      end
+    end
+
+    context 'when avoid_motorways is disabled' do
+      let(:calculator) { described_class.new(start_location, destination, [], avoid_motorways: false) }
+
+      before do
+        allow(calculator).to receive(:geocode).with(start_location)
+                                              .and_return([ 40.7128, -74.0060 ])
+        allow(calculator).to receive(:geocode).with(destination)
+                                              .and_return([ 42.3601, -71.0589 ])
+        allow(Net::HTTP).to receive(:get_response).and_return(
+          instance_double(Net::HTTPSuccess, is_a?: true, body: {
+            routes: [{ distance: 300000, duration: 14400 }] # Normal route
+          }.to_json)
+        )
+      end
+
+      it 'does not pass avoid parameter to OSRM API' do
+        expect(URI).to receive(:encode_www_form).with(
+          hash_not_including(:avoid)
+        ).and_call_original
+
+        calculator.calculate
       end
     end
   end

--- a/spec/system/fuel_economy_spec.rb
+++ b/spec/system/fuel_economy_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe "Fuel Economy Calculator", type: :system, js: true do
       # Mock the RouteDistanceCalculator to return nil distance
       calculator = instance_double(RouteDistanceCalculator)
       allow(RouteDistanceCalculator).to receive(:new)
-        .with(route_without_distance.starting_location, route_without_distance.destination, [])
+        .with(route_without_distance.starting_location, route_without_distance.destination, [], avoid_motorways: false)
         .and_return(calculator)
       allow(calculator).to receive(:calculate).and_return({ distance: nil, duration: nil })
 


### PR DESCRIPTION
## Summary
- Added checkbox option to route creation forms to avoid motorways/highways
- Route planning now respects the motorway avoidance setting via OSRM API
- Setting is route-specific and affects all route calculations including waypoints
- Added comprehensive tests for the new functionality

## Test plan
- [x] Database migration adds avoid_motorways column with proper defaults
- [x] Route model handles avoid_motorways attribute and triggers recalculation
- [x] Route forms display avoid_motorways checkbox in both create and edit modes  
- [x] Routes controller accepts avoid_motorways parameter in strong params
- [x] RouteDistanceCalculator passes avoid=motorway to OSRM API when enabled
- [x] Waypoint editing preserves and respects avoid_motorways setting
- [x] All existing tests continue to pass with updated mocks
- [x] RuboCop style checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)