### PR TITLE
Feature: Make packing list items optional

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ The application uses OpenRouteService for guaranteed highway and toll avoidance 
 - RSpec test suite setup
 - Basic navigation and layout components
 - Road trip management with route planning
-- Packing list functionality with categories, progress tracking, and privacy controls (private/public visibility)
+- Packing list functionality with categories, progress tracking, optional items, and privacy controls (private/public visibility)
 - About page with feature descriptions and user onboarding
 - Road trip sharing with other users (add participants, leave functionality, access control)
 - Fuel economy calculator with real-time cost calculations (client-side JavaScript)

--- a/app/components/packing_list_items/edit_component.rb
+++ b/app/components/packing_list_items/edit_component.rb
@@ -168,6 +168,25 @@ class PackingListItems::EditComponent < ApplicationComponent
               end
             end
 
+            # Optional checkbox
+            div do
+              div class: "flex items-center" do
+                form.check_box :optional,
+                               class: "h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+
+                form.label :optional,
+                          class: "ml-2 block text-sm text-gray-700" do
+                  "Optional item (won't count toward packing progress)"
+                end
+              end
+
+              if @packing_list_item.errors[:optional].any?
+                div class: "mt-1 text-sm text-red-600" do
+                  @packing_list_item.errors[:optional].first
+                end
+              end
+            end
+
             div class: "flex items-center justify-between pt-4" do
               link_to road_trip_packing_list_path(@road_trip, @packing_list),
                       class: "inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2" do

--- a/app/components/packing_list_items/new_component.rb
+++ b/app/components/packing_list_items/new_component.rb
@@ -152,6 +152,25 @@ class PackingListItems::NewComponent < ApplicationComponent
               end
             end
 
+            # Optional checkbox
+            div do
+              div class: "flex items-center" do
+                form.check_box :optional,
+                               class: "h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+
+                form.label :optional,
+                          class: "ml-2 block text-sm text-gray-700" do
+                  "Optional item (won't count toward packing progress)"
+                end
+              end
+
+              if @packing_list_item.errors[:optional].any?
+                div class: "mt-1 text-sm text-red-600" do
+                  @packing_list_item.errors[:optional].first
+                end
+              end
+            end
+
             div class: "flex items-center justify-between pt-4" do
               link_to road_trip_packing_list_path(@road_trip, @packing_list),
                       class: "inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2" do

--- a/app/components/packing_lists/show_component.rb
+++ b/app/components/packing_lists/show_component.rb
@@ -272,12 +272,22 @@ class PackingLists::ShowComponent < ApplicationComponent
           # Item details
           div class: "flex-1" do
             div class: "flex items-center space-x-2" do
-              span class: "text-base font-medium #{item.packed? ? 'text-gray-500 line-through' : 'text-gray-900'}" do
+              text_classes = []
+              text_classes << (item.packed? ? 'line-through' : '')
+              text_classes << (item.optional? ? 'text-gray-400' : (item.packed? ? 'text-gray-500' : 'text-gray-900'))
+              text_classes << 'font-medium'
+
+              span class: "text-base #{text_classes.join(' ')}" do
                 item.name
               end
               if item.quantity > 1
                 span class: "inline-flex items-center px-2 py-1 text-xs font-medium bg-gray-100 text-gray-800 rounded-full" do
                   "×#{item.quantity}"
+                end
+              end
+              if item.optional?
+                span class: "inline-flex items-center px-2 py-1 text-xs font-medium bg-yellow-100 text-yellow-800 rounded-full" do
+                  "Optional"
                 end
               end
             end

--- a/app/components/packing_lists/show_component.rb
+++ b/app/components/packing_lists/show_component.rb
@@ -273,9 +273,9 @@ class PackingLists::ShowComponent < ApplicationComponent
           div class: "flex-1" do
             div class: "flex items-center space-x-2" do
               text_classes = []
-              text_classes << (item.packed? ? 'line-through' : '')
-              text_classes << (item.optional? ? 'text-gray-400' : (item.packed? ? 'text-gray-500' : 'text-gray-900'))
-              text_classes << 'font-medium'
+              text_classes << (item.packed? ? "line-through" : "")
+              text_classes << (item.optional? ? "text-gray-400" : (item.packed? ? "text-gray-500" : "text-gray-900"))
+              text_classes << "font-medium"
 
               span class: "text-base #{text_classes.join(' ')}" do
                 item.name

--- a/app/controllers/packing_list_items_controller.rb
+++ b/app/controllers/packing_list_items_controller.rb
@@ -100,6 +100,6 @@ class PackingListItemsController < ApplicationController
   end
 
   def packing_list_item_params
-    params.require(:packing_list_item).permit(:name, :quantity, :category, :packed)
+    params.require(:packing_list_item).permit(:name, :quantity, :category, :packed, :optional)
   end
 end

--- a/app/models/packing_list.rb
+++ b/app/models/packing_list.rb
@@ -17,11 +17,11 @@ class PackingList < ApplicationRecord
   scope :private_lists, -> { where(visibility: "private") }
 
   def total_items_count
-    packing_list_items.sum(:quantity)
+    packing_list_items.required_items.sum(:quantity)
   end
 
   def packed_items_count
-    packing_list_items.where(packed: true).sum(:quantity)
+    packing_list_items.required_items.where(packed: true).sum(:quantity)
   end
 
   def packing_progress

--- a/app/models/packing_list_item.rb
+++ b/app/models/packing_list_item.rb
@@ -5,6 +5,7 @@ class PackingListItem < ApplicationRecord
   validates :quantity, presence: true, numericality: { greater_than: 0, only_integer: true }
   validates :category, presence: true
   validates :packed, inclusion: { in: [ true, false ] }
+  validates :optional, inclusion: { in: [ true, false ] }
 
   enum :category, {
     tools: "tools",
@@ -20,6 +21,8 @@ class PackingListItem < ApplicationRecord
 
   scope :packed, -> { where(packed: true) }
   scope :unpacked, -> { where(packed: false) }
+  scope :optional_items, -> { where(optional: true) }
+  scope :required_items, -> { where(optional: false) }
   scope :by_category, ->(cat) { where(category: cat) }
 
   def toggle_packed!

--- a/db/migrate/20250916064848_add_optional_to_packing_list_items.rb
+++ b/db/migrate/20250916064848_add_optional_to_packing_list_items.rb
@@ -1,0 +1,5 @@
+class AddOptionalToPackingListItems < ActiveRecord::Migration[8.0]
+  def change
+    add_column :packing_list_items, :optional, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_15_192145) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_16_064848) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -22,6 +22,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_15_192145) do
     t.bigint "packing_list_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "optional", default: false, null: false
     t.index ["packing_list_id"], name: "index_packing_list_items_on_packing_list_id"
   end
 

--- a/spec/factories/packing_list_items.rb
+++ b/spec/factories/packing_list_items.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     quantity { 1 }
     category { "other" }
     packed { false }
+    optional { false }
     association :packing_list
 
     trait :packed do
@@ -12,6 +13,14 @@ FactoryBot.define do
 
     trait :unpacked do
       packed { false }
+    end
+
+    trait :optional do
+      optional { true }
+    end
+
+    trait :required do
+      optional { false }
     end
 
     trait :clothes_item do

--- a/spec/models/packing_list_item_spec.rb
+++ b/spec/models/packing_list_item_spec.rb
@@ -69,6 +69,18 @@ RSpec.describe PackingListItem, type: :model do
       subject.packed = false
       expect(subject).to be_valid
     end
+
+    it 'validates optional is boolean' do
+      subject.optional = nil
+      expect(subject).not_to be_valid
+      expect(subject.errors[:optional]).to include("is not included in the list")
+
+      subject.optional = true
+      expect(subject).to be_valid
+
+      subject.optional = false
+      expect(subject).to be_valid
+    end
   end
 
   describe 'enums' do
@@ -92,6 +104,8 @@ RSpec.describe PackingListItem, type: :model do
     let(:packing_list) { create(:packing_list) }
     let!(:packed_item) { create(:packing_list_item, packing_list: packing_list, packed: true) }
     let!(:unpacked_item) { create(:packing_list_item, packing_list: packing_list, packed: false) }
+    let!(:optional_item) { create(:packing_list_item, packing_list: packing_list, optional: true) }
+    let!(:required_item) { create(:packing_list_item, packing_list: packing_list, optional: false) }
     let!(:clothes_item) { create(:packing_list_item, packing_list: packing_list, category: "clothes") }
     let!(:tools_item) { create(:packing_list_item, packing_list: packing_list, category: "tools") }
 
@@ -105,7 +119,21 @@ RSpec.describe PackingListItem, type: :model do
     describe '.unpacked' do
       it 'returns only unpacked items' do
         unpacked_items_from_test = packing_list.packing_list_items.unpacked
-        expect(unpacked_items_from_test).to contain_exactly(unpacked_item, clothes_item, tools_item)
+        expect(unpacked_items_from_test).to contain_exactly(unpacked_item, optional_item, required_item, clothes_item, tools_item)
+      end
+    end
+
+    describe '.optional_items' do
+      it 'returns only optional items' do
+        optional_items_from_test = packing_list.packing_list_items.optional_items
+        expect(optional_items_from_test).to contain_exactly(optional_item)
+      end
+    end
+
+    describe '.required_items' do
+      it 'returns only required items' do
+        required_items_from_test = packing_list.packing_list_items.required_items
+        expect(required_items_from_test).to contain_exactly(packed_item, unpacked_item, required_item, clothes_item, tools_item)
       end
     end
 

--- a/spec/models/packing_list_spec.rb
+++ b/spec/models/packing_list_spec.rb
@@ -69,12 +69,20 @@ RSpec.describe PackingList, type: :model do
       expect(packing_list.total_items_count).to eq(0)
     end
 
-    it 'returns the sum of all item quantities' do
-      create(:packing_list_item, packing_list: packing_list, quantity: 3)
-      create(:packing_list_item, packing_list: packing_list, quantity: 2)
-      create(:packing_list_item, packing_list: packing_list, quantity: 1)
+    it 'returns the sum of all required item quantities' do
+      create(:packing_list_item, packing_list: packing_list, quantity: 3, optional: false)
+      create(:packing_list_item, packing_list: packing_list, quantity: 2, optional: false)
+      create(:packing_list_item, packing_list: packing_list, quantity: 1, optional: false)
 
       expect(packing_list.total_items_count).to eq(6)
+    end
+
+    it 'excludes optional items from count' do
+      create(:packing_list_item, packing_list: packing_list, quantity: 3, optional: false)
+      create(:packing_list_item, packing_list: packing_list, quantity: 2, optional: true)
+      create(:packing_list_item, packing_list: packing_list, quantity: 1, optional: false)
+
+      expect(packing_list.total_items_count).to eq(4)
     end
   end
 
@@ -82,14 +90,22 @@ RSpec.describe PackingList, type: :model do
     let(:packing_list) { create(:packing_list) }
 
     it 'returns 0 for no packed items' do
-      create(:packing_list_item, packing_list: packing_list, packed: false, quantity: 3)
+      create(:packing_list_item, packing_list: packing_list, packed: false, quantity: 3, optional: false)
       expect(packing_list.packed_items_count).to eq(0)
     end
 
-    it 'returns the sum of packed item quantities' do
-      create(:packing_list_item, packing_list: packing_list, packed: true, quantity: 3)
-      create(:packing_list_item, packing_list: packing_list, packed: false, quantity: 2)
-      create(:packing_list_item, packing_list: packing_list, packed: true, quantity: 1)
+    it 'returns the sum of packed required item quantities' do
+      create(:packing_list_item, packing_list: packing_list, packed: true, quantity: 3, optional: false)
+      create(:packing_list_item, packing_list: packing_list, packed: false, quantity: 2, optional: false)
+      create(:packing_list_item, packing_list: packing_list, packed: true, quantity: 1, optional: false)
+
+      expect(packing_list.packed_items_count).to eq(4)
+    end
+
+    it 'excludes optional items from packed count' do
+      create(:packing_list_item, packing_list: packing_list, packed: true, quantity: 3, optional: false)
+      create(:packing_list_item, packing_list: packing_list, packed: true, quantity: 2, optional: true)
+      create(:packing_list_item, packing_list: packing_list, packed: true, quantity: 1, optional: false)
 
       expect(packing_list.packed_items_count).to eq(4)
     end
@@ -117,10 +133,20 @@ RSpec.describe PackingList, type: :model do
     end
 
     it 'rounds to one decimal place' do
-      create(:packing_list_item, packing_list: packing_list, packed: true, quantity: 1)
-      create(:packing_list_item, packing_list: packing_list, packed: false, quantity: 2)
+      create(:packing_list_item, packing_list: packing_list, packed: true, quantity: 1, optional: false)
+      create(:packing_list_item, packing_list: packing_list, packed: false, quantity: 2, optional: false)
 
       expect(packing_list.packing_progress).to eq(33.3)
+    end
+
+    it 'excludes optional items from progress calculation' do
+      create(:packing_list_item, packing_list: packing_list, packed: true, quantity: 2, optional: false)
+      create(:packing_list_item, packing_list: packing_list, packed: false, quantity: 2, optional: false)
+      create(:packing_list_item, packing_list: packing_list, packed: true, quantity: 5, optional: true)
+      create(:packing_list_item, packing_list: packing_list, packed: false, quantity: 3, optional: true)
+
+      # Progress should be 50% (2 packed / 4 total required items)
+      expect(packing_list.packing_progress).to eq(50.0)
     end
   end
 


### PR DESCRIPTION
## Summary
- Add optional boolean field to packing list items with database migration
- Update forms (new/edit) to include optional checkbox with descriptive text
- Modify progress calculation to exclude optional items from count
- Style optional items with lighter font color and yellow "Optional" badge
- Comprehensive test coverage for new functionality

## Implementation Details
- **Database**: Added `optional` boolean field with default `false` to maintain existing behavior
- **UI Forms**: Added checkbox with label "Optional item (won't count toward packing progress)"
- **Display**: Optional items show with gray-400 text color and yellow "Optional" badge
- **Progress**: Only required items count toward total and packed counts for progress calculation
- **Tests**: Full coverage including model validations, scopes, and progress calculation exclusion

## Test Plan
- [x] Create optional and required items via forms
- [x] Verify optional items display with different styling
- [x] Confirm progress calculation excludes optional items
- [x] Validate all existing functionality still works
- [x] All tests passing (434 examples, 0 failures)
- [x] RuboCop linting passes
- [x] Zeitwerk autoloading check passes

🤖 Generated with [Claude Code](https://claude.ai/code)