### PR TITLE
Add participant count display to road trip index page

### DIFF
--- a/app/components/road_trips/index_component.rb
+++ b/app/components/road_trips/index_component.rb
@@ -83,6 +83,10 @@ class RoadTrips::IndexComponent < ApplicationComponent
             span class: "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800" do
               "#{road_trip.routes.count} routes"
             end
+
+            span class: "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800" do
+              "#{road_trip.participant_count} #{'participant'.pluralize(road_trip.participant_count)}"
+            end
           end
         end
 

--- a/app/models/road_trip.rb
+++ b/app/models/road_trip.rb
@@ -46,6 +46,6 @@ class RoadTrip < ApplicationRecord
   end
 
   def participant_count
-    participants.count + 1
+    participants.count + 1 # x invitees + 1 owner
   end
 end

--- a/app/models/road_trip.rb
+++ b/app/models/road_trip.rb
@@ -44,4 +44,8 @@ class RoadTrip < ApplicationRecord
   def remove_participant(participant_user)
     participants.delete(participant_user)
   end
+
+  def participant_count
+    participants.count + 1
+  end
 end

--- a/spec/models/road_trip_spec.rb
+++ b/spec/models/road_trip_spec.rb
@@ -247,5 +247,27 @@ RSpec.describe RoadTrip, type: :model do
         }.not_to change { road_trip.participants.count }
       end
     end
+
+    describe '#participant_count' do
+      it 'returns 1 when there are no participants (owner only)' do
+        expect(road_trip.participant_count).to eq(1)
+      end
+
+      it 'returns the correct count including owner and participants' do
+        road_trip.add_participant(participant1)
+        road_trip.add_participant(participant2)
+
+        expect(road_trip.participant_count).to eq(3) # owner + 2 participants
+      end
+
+      it 'decreases when participants are removed' do
+        road_trip.add_participant(participant1)
+        road_trip.add_participant(participant2)
+        expect(road_trip.participant_count).to eq(3)
+
+        road_trip.remove_participant(participant1)
+        expect(road_trip.participant_count).to eq(2) # owner + 1 participant
+      end
+    end
   end
 end

--- a/spec/system/road_trip_sharing_spec.rb
+++ b/spec/system/road_trip_sharing_spec.rb
@@ -102,6 +102,13 @@ RSpec.describe 'Road Trip Sharing', type: :system do
       expect(page).to have_content('Shared')
     end
 
+    it 'displays participant count on road trip index' do
+      login_as(participant)
+      visit road_trips_path
+
+      expect(page).to have_content('2 participants')
+    end
+
     it 'allows participants to access shared road trips' do
       login_as(participant)
       visit road_trip_path(road_trip)
@@ -122,6 +129,40 @@ RSpec.describe 'Road Trip Sharing', type: :system do
 
       expect(page).to have_current_path(road_trips_path)
       expect(page).to have_content('You have left the road trip')
+    end
+  end
+
+  describe 'Participant count display' do
+    it 'shows correct participant count for owner with no participants' do
+      # Ensure the road trip exists by accessing it
+      road_trip
+      login_as(owner)
+      visit road_trips_path
+
+      expect(page).to have_content('1 participant')
+    end
+
+    it 'shows correct participant count for owner with multiple participants' do
+      road_trip.participants << participant
+      road_trip.participants << other_user
+      login_as(owner)
+      visit road_trips_path
+
+      expect(page).to have_content('3 participants')
+    end
+
+    it 'shows participant count with proper pluralization' do
+      # Ensure the road trip exists by accessing it
+      road_trip
+      login_as(owner)
+      visit road_trips_path
+
+      expect(page).to have_content('1 participant')
+
+      road_trip.participants << participant
+      visit road_trips_path
+
+      expect(page).to have_content('2 participants')
     end
   end
 


### PR DESCRIPTION
## Summary
- Adds participant count display to road trip index page as purple badges
- Shows count for both owned trips and trips shared with user
- Includes owner in the participant count (owner + participants)
- Displays proper pluralization (1 participant vs 2 participants)

## Implementation Details
- Added `participant_count` method to `RoadTrip` model
- Updated `RoadTrips::IndexComponent` to display participant count badges
- Added comprehensive model and system tests
- All tests pass and linting checks succeed

## Test Plan
- [x] Model tests verify participant count calculation
- [x] System tests verify display on index page for various scenarios
- [x] Tests cover proper pluralization
- [x] Tests cover both owner and participant perspectives
- [x] All existing tests continue to pass

## Fixes
Closes #81

🤖 Generated with [Claude Code](https://claude.ai/code)